### PR TITLE
chore: redirect to alternate donations site

### DIFF
--- a/stripe-node/app.js
+++ b/stripe-node/app.js
@@ -5,6 +5,8 @@ const app = express();
 const routes = require('./routes/routes');
 // Set routes
 app.use('/', routes);
+
+/*
 // Todo: Error handling
 app.use((req, res, next) => {
   const err = new Error('Not Found');
@@ -19,6 +21,8 @@ app.use((err, req, res, next) => {
       message: err,
     });
 });
+*/
+
 // Listen on port 4567
 app.listen(process.env.PORT || 4567, () => {
   console.log('Running on port 4567');

--- a/stripe-node/routes/routes.js
+++ b/stripe-node/routes/routes.js
@@ -1,6 +1,8 @@
 // Call libraries
 const express = require('express');
 const router = express.Router();
+
+/*
 const bodyParser = require('body-parser');
 const charge = require('../api/charge');
 const path = require('path');
@@ -22,6 +24,11 @@ router.use('/', express.static('../dist/', {index: 'app.view.html'}));
 router.all('/*', function(req,res,next) {
   console.log(req.method + ' ' + req.path);
   res.sendFile(path.join(__dirname, '../../dist/app.view.html'));
+});
+*/
+
+router.all('/*', function(req,res,next) {
+  res.redirect('https://donate.givedirect.org/?cid=13536&n=713766&desig=Keyman');
 });
 
 module.exports = router;


### PR DESCRIPTION
This is a temporary patch until SIL's new donations infrastructure comes online.

Due to fraud attempts becoming far too frequent on donate.keyman.com, for now we are disabling the site and redirecting to a generic SIL donations site. This is in no way ideal, but we had to deal with nearly 600 fraud attempts in 4 hours today, and we don't want to do that any more.